### PR TITLE
Add libasound2-dev to install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sound card schematics will be published on https://github.com/nabaztag2018/hardw
 
 Install requirements
 
-    sudo apt-get install raspberrypi-kernel-headers
+    sudo apt-get install raspberrypi-kernel-headers libasound2-dev
 
 Clone source code.
 


### PR DESCRIPTION
During my installation from pynab instructions, libasound2-dev was not yet installed in Raspbian Buster Lite. So this will fix the problem for the others.