### PR TITLE
Fix tagtagtag-mixerd build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ install: snd-soc-wm8960.ko snd-soc-max9759.ko snd-soc-volume-gpio.ko tagtagtag-s
 	systemctl enable tagtagtag-mixerd
 
 tagtagtag-mixerd : tagtagtag-mixerd.c
-	cc -Wall -Werror -lasound -lpthread $< -o $@
+	cc -Wall -Werror $< -lasound -lpthread -o $@
 
 tagtagtag-mixerd-test : tagtagtag-mixerd.c
-	cc -Wall -Werror -lasound -lpthread -DTEST $< -o $@
+	cc -Wall -Werror -DTEST $< -lasound -lpthread -o $@
 
 test : tagtagtag-mixerd-test
 	./tagtagtag-mixerd-test


### PR DESCRIPTION
Resolves #13.
GCC 10 appears to be less lenient than GCC 8 for options order: libraries should appear **after** source file, otherwise link fails.
