### PR TITLE
Raspbian11 kernel5.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ obj-m += snd-soc-volume-gpio.o
 dtbo-y += tagtagtag-sound.dtbo
 
 targets += $(dtbo-y)
-always  := $(dtbo-y)
+always-y := $(dtbo-y)
 
 all: tagtagtag-mixerd
 	make -C /usr/src/linux-headers-$(KERNELRELEASE) M=$(shell pwd) modules

--- a/wm8960.c
+++ b/wm8960.c
@@ -1352,7 +1352,11 @@ static struct snd_soc_dai_driver wm8960_dai = {
 		.rates = WM8960_RATES,
 		.formats = WM8960_FORMATS,},
 	.ops = &wm8960_dai_ops,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,15,0)
 	.symmetric_rates = 1,
+#else
+	.symmetric_rate = 1,
+#endif
 };
 
 static int wm8960_probe(struct snd_soc_component *component)


### PR DESCRIPTION
This is the change required for a proper driver build on a raspbian 11 running the latest kernel (5.15.32).