### PR TITLE
Fix compilation and installation on newer kernels

### DIFF
--- a/.github/workflows/arm-runner.yml
+++ b/.github/workflows/arm-runner.yml
@@ -49,13 +49,14 @@ jobs:
         base_image: ${{ matrix.base_image }}
         cpu: ${{ matrix.cpu }}
         commands: |
+            apt-get update -y --allow-releaseinfo-change
             kernel_headers_pkg=`apt-cache show raspberrypi-kernel-headers | sed -n -e 's|Filename: .*/||p'`
             wget -q http://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware/${kernel_headers_pkg}
             dpkg --install ${kernel_headers_pkg}
-            apt-get update -y --allow-releaseinfo-change
             apt-get install --no-install-recommends -y libasound2-dev make gcc libc6-dev
             for builddir in /lib/modules/*/build ; do
                 parentdir=`dirname ${builddir}`
+                mkdir -p ${parentdir}/kernel/sound/soc/codecs/
                 kernelrelease=`basename ${parentdir}`
                 make KERNELRELEASE=${kernelrelease}
                 sudo make install KERNELRELEASE=${kernelrelease}

--- a/Makefile
+++ b/Makefile
@@ -18,27 +18,49 @@ else
 	always-y := $(dtbo-y)
 endif
 
+ifeq ($(wildcard /boot/firmware/config.txt),)
+    BOOT_CONFIG := /boot/config.txt
+else
+    BOOT_CONFIG := /boot/firmware/config.txt
+endif
+
 all: tagtagtag-mixerd
 	make -C /usr/src/linux-headers-$(KERNELRELEASE) M=$(shell pwd) modules
+
+# dtbo rule is no longer available
+ifeq ($(firstword $(subst ., ,$(KERNELRELEASE))),6)
+all: tagtagtag-sound.dtbo
+
+tagtagtag-sound.dtbo: tagtagtag-sound-overlay-patched.dts
+	dtc -I dts -O dtb -o $@ $<
+
+tagtagtag-sound-overlay-patched.dts: tagtagtag-sound-overlay.dts
+	sed -e "s|^#define EXTCON_JACK_LINE_OUT 23|/* #define EXTCON_JACK_LINE_OUT 23 */|" $< > $@
+endif
 
 clean:
 	make -C /usr/src/linux-headers-$(KERNELRELEASE) M=$(shell pwd) clean
 	rm -f tagtagtag-mixerd tagtagtag-mixerd-test
 
 install: snd-soc-wm8960.ko snd-soc-max9759.ko snd-soc-volume-gpio.ko tagtagtag-sound.dtbo tagtagtag-mixerd
+	if test -e /lib/modules/$(KERNELRELEASE)/kernel/sound/soc/codecs/snd-soc-wm8960.ko.xz; then \
+	    echo "Disabling built-in wm8960 driver" ; \
+	    mv /lib/modules/$(KERNELRELEASE)/kernel/sound/soc/codecs/snd-soc-wm8960.ko.xz \
+	        /lib/modules/$(KERNELRELEASE)/kernel/sound/soc/codecs/snd-soc-wm8960.ko.xz.disabled ; \
+	fi
 	install -o root -m 644 snd-soc-wm8960.ko /lib/modules/$(KERNELRELEASE)/kernel/sound/soc/codecs/
 	install -o root -m 644 snd-soc-max9759.ko /lib/modules/$(KERNELRELEASE)/kernel/sound/soc/codecs/
 	install -o root -m 644 snd-soc-volume-gpio.ko /lib/modules/$(KERNELRELEASE)/kernel/sound/soc/codecs/
 	depmod -a $(KERNELRELEASE)
 	install -o root -m 644 tagtagtag-sound.dtbo /boot/overlays/
-	sed /boot/config.txt -i -e "s/^#dtparam=i2c_arm=on/dtparam=i2c_arm=on/"
-	grep -q -E "^dtparam=i2c_arm=on" /boot/config.txt || printf "dtparam=i2c_arm=on\n" >> /boot/config.txt
-	sed /boot/config.txt -i -e "s/^#dtoverlay=i2s-mmap/dtoverlay=i2s-mmap/"
-	grep -q -E "^dtoverlay=i2s-mmap" /boot/config.txt || printf "dtoverlay=i2s-mmap\n" >> /boot/config.txt
-	sed /boot/config.txt -i -e "s/^#dtparam=i2s=on/dtparam=i2s=on/"
-	grep -q -E "^dtparam=i2s=on" /boot/config.txt || printf "dtparam=i2s=on\n" >> /boot/config.txt
-	sed /boot/config.txt -i -e "s/^#dtoverlay=tagtagtag-sound/dtoverlay=tagtagtag-sound/"
-	grep -q -E "^dtoverlay=tagtagtag-sound" /boot/config.txt || printf "dtoverlay=tagtagtag-sound\n" >> /boot/config.txt
+	sed $(BOOT_CONFIG) -i -e "s/^#dtparam=i2c_arm=on/dtparam=i2c_arm=on/"
+	grep -q -E "^dtparam=i2c_arm=on" $(BOOT_CONFIG) || printf "dtparam=i2c_arm=on\n" >> $(BOOT_CONFIG)
+	sed $(BOOT_CONFIG) -i -e "s/^#dtoverlay=i2s-mmap/dtoverlay=i2s-mmap/"
+	grep -q -E "^dtoverlay=i2s-mmap" $(BOOT_CONFIG) || printf "dtoverlay=i2s-mmap\n" >> $(BOOT_CONFIG)
+	sed $(BOOT_CONFIG) -i -e "s/^#dtparam=i2s=on/dtparam=i2s=on/"
+	grep -q -E "^dtparam=i2s=on" $(BOOT_CONFIG) || printf "dtparam=i2s=on\n" >> $(BOOT_CONFIG)
+	sed $(BOOT_CONFIG) -i -e "s/^#dtoverlay=tagtagtag-sound/dtoverlay=tagtagtag-sound/"
+	grep -q -E "^dtoverlay=tagtagtag-sound" $(BOOT_CONFIG) || printf "dtoverlay=tagtagtag-sound\n" >> $(BOOT_CONFIG)
 	install -D -o root -m 644 mixer.conf.default /var/lib/tagtagtag-sound/mixer.conf.default
 	test -e /var/lib/tagtagtag-sound/mixer.conf || install -o root -m 644 mixer.conf.default /var/lib/tagtagtag-sound/mixer.conf
 	install -o root -m 755 tagtagtag-mixerd /usr/local/sbin/tagtagtag-mixerd

--- a/wm8960.c
+++ b/wm8960.c
@@ -749,7 +749,6 @@ static int wm8960_configure_clocking(struct snd_soc_component *component)
 {
 	struct wm8960_priv *wm8960 = snd_soc_component_get_drvdata(component);
 	int freq_out, freq_in;
-	u16 iface1 = snd_soc_component_read(component, WM8960_IFACE1);
 	int i, j, k;
 	int ret;
 
@@ -1412,8 +1411,12 @@ static void wm8960_set_pdata_from_of(struct i2c_client *i2c,
 		pdata->shared_lrclk = true;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,6,0)
 static int wm8960_i2c_probe(struct i2c_client *i2c,
 			    const struct i2c_device_id *id)
+#else
+static int wm8960_i2c_probe(struct i2c_client *i2c)
+#endif
 {
 	struct wm8960_data *pdata = dev_get_platdata(&i2c->dev);
 	struct wm8960_priv *wm8960;


### PR DESCRIPTION
Always remove upstream module, even if it's compressed
Fix compilation on 6.6